### PR TITLE
WIN32: use FolderItem ShellPath

### DIFF
--- a/sources/CubeSQLPlugin.cpp
+++ b/sources/CubeSQLPlugin.cpp
@@ -1810,21 +1810,14 @@ REALstring CheckFixEscapedStringPath (REALstring s) {
 }
 
 REALstring REALbasicPathFromFolderItem (REALfolderItem value) {
-	REALstring path = NULL;
 	DEBUG_WRITE("REALbasicPathFromFolderItem");
-    
-    double v = REALGetRBVersion();
-    if (v <= 2012.021) { // 2012R2.1 is the latest Real Studio edition
-        #if WIN32
-        if (REALGetPropValueString((REALobject)value, "AbsolutePath", &path) == false) return NULL;
-        #else
-        if (REALGetPropValueString((REALobject)value, "ShellPath", &path) == false) return NULL;
-        path = CheckFixEscapedStringPath(path);
-        #endif
-    } else {
-        // NativePath property is supported only on Xojo and it is the recommended way to get path from FolderItem
-        if (REALGetPropValueString((REALobject)value, "NativePath", &path) == false) return NULL;
-    }
+	REALstring path = NULL;
+
+#if WIN32
+	if (REALGetPropValueString((REALobject)value, "ShellPath", &path) == false) return NULL;
+#else
+	if (REALGetPropValueString((REALobject)value, "NativePath", &path) == false) return NULL;
+#endif
 	
 	REALLockString(path);
 	return path;

--- a/sources/CubeSQLPlugin.h
+++ b/sources/CubeSQLPlugin.h
@@ -13,7 +13,7 @@
 
 #define	PING_FREQUENCY		300 // on the server it is specified as 300
 #define DEBUG_WRITE(...)	if (debugFile != NULL) debug_write(__VA_ARGS__)
-#define PLUGIN_VERSION		"3.2.1"
+#define PLUGIN_VERSION		"3.2.2"
 #define SSL_NOVERSION		"N/A"
 #define MAX_TYPES_COUNT     512
 


### PR DESCRIPTION
This fixes the issue (on Windows) that a RootCertificate located in a folder containing special characters (e.g. "Test Jürg") can't be opened.